### PR TITLE
Feat(#8): 회원 유형 수정 기능 구현

### DIFF
--- a/src/main/java/com/moa/moabackend/member/api/MemberController.java
+++ b/src/main/java/com/moa/moabackend/member/api/MemberController.java
@@ -1,0 +1,31 @@
+package com.moa.moabackend.member.api;
+
+import com.moa.moabackend.global.template.RspTemplate;
+import com.moa.moabackend.member.api.dto.request.MemberTypeUpdateReqDto;
+import com.moa.moabackend.member.application.MemberService;
+import com.moa.moabackend.member.domain.Member;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/members")
+public class MemberController implements MemberControllerDocs {
+
+    private final MemberService memberService;
+
+    public MemberController(MemberService memberService) {
+        this.memberService = memberService;
+    }
+
+    @PatchMapping("/type")
+    public RspTemplate<Void> updateMemberType(@AuthenticationPrincipal Member member,
+                                              @RequestBody MemberTypeUpdateReqDto memberTypeUpdateReqDto) {
+        memberService.updateMemberType(member.getEmail(), memberTypeUpdateReqDto.toMemberType());
+        return new RspTemplate<>(HttpStatus.OK, "회원 유형 수정 완료");
+    }
+
+}

--- a/src/main/java/com/moa/moabackend/member/api/MemberControllerDocs.java
+++ b/src/main/java/com/moa/moabackend/member/api/MemberControllerDocs.java
@@ -1,0 +1,21 @@
+package com.moa.moabackend.member.api;
+
+import com.moa.moabackend.global.template.RspTemplate;
+import com.moa.moabackend.member.api.dto.request.MemberTypeUpdateReqDto;
+import com.moa.moabackend.member.domain.Member;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestBody;
+
+public interface MemberControllerDocs {
+
+    @Operation(summary = "회원 유형 변경 API", description = "회원 가입 후 회원 유형을 선택하는 API 입니다. 회원 유형은 INVESTOR 또는 BUSINESS 중 하나여야 합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "회원 유형 변경 성공")
+    })
+    RspTemplate<Void> updateMemberType(@AuthenticationPrincipal Member member,
+                                       @RequestBody MemberTypeUpdateReqDto memberTypeUpdateReqDto);
+
+}

--- a/src/main/java/com/moa/moabackend/member/api/dto/request/MemberTypeUpdateReqDto.java
+++ b/src/main/java/com/moa/moabackend/member/api/dto/request/MemberTypeUpdateReqDto.java
@@ -1,0 +1,11 @@
+package com.moa.moabackend.member.api.dto.request;
+
+import com.moa.moabackend.member.domain.MemberType;
+
+public record MemberTypeUpdateReqDto(
+        String memberType
+) {
+    public MemberType toMemberType() {
+        return MemberType.fromString(this.memberType);
+    }
+}

--- a/src/main/java/com/moa/moabackend/member/application/MemberService.java
+++ b/src/main/java/com/moa/moabackend/member/application/MemberService.java
@@ -1,0 +1,26 @@
+package com.moa.moabackend.member.application;
+
+import com.moa.moabackend.member.domain.Member;
+import com.moa.moabackend.member.domain.MemberType;
+import com.moa.moabackend.member.domain.repository.MemberRepository;
+import com.moa.moabackend.member.exception.MemberNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    public MemberService(MemberRepository memberRepository) {
+        this.memberRepository = memberRepository;
+    }
+
+    @Transactional
+    public void updateMemberType(String email, MemberType memberType) {
+        Member member = memberRepository.findByEmail(email).orElseThrow(MemberNotFoundException::new);
+        member.updateMemberType(memberType);
+    }
+
+}

--- a/src/main/java/com/moa/moabackend/member/domain/Member.java
+++ b/src/main/java/com/moa/moabackend/member/domain/Member.java
@@ -41,6 +41,9 @@ public class Member extends BaseEntity {
     @Enumerated(value = EnumType.STRING)
     private SocialType socialType;
 
+    @Enumerated(value = EnumType.STRING)
+    private MemberType memberType;
+
     @OneToMany(mappedBy = "member", orphanRemoval = true, cascade = CascadeType.ALL)
     private List<StorePunding> storePundings = new ArrayList<>();
 
@@ -60,6 +63,10 @@ public class Member extends BaseEntity {
         this.picture = picture;
         this.nickname = nickname;
         this.socialType = socialType;
+    }
+
+    public void updateMemberType(MemberType memberType) {
+        this.memberType = memberType;
     }
 
 }

--- a/src/main/java/com/moa/moabackend/member/domain/MemberType.java
+++ b/src/main/java/com/moa/moabackend/member/domain/MemberType.java
@@ -1,0 +1,23 @@
+package com.moa.moabackend.member.domain;
+
+import com.moa.moabackend.member.exception.InvalidMemberTypeException;
+
+public enum MemberType {
+    INVESTOR("투자자"),
+    BUSINESS("업체");
+
+    private String description;
+
+    MemberType(String description) {
+        this.description = description;
+    }
+
+    public static MemberType fromString(String value) {
+        try {
+            return MemberType.valueOf(value.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new InvalidMemberTypeException();
+        }
+    }
+
+}

--- a/src/main/java/com/moa/moabackend/member/exception/InvalidMemberTypeException.java
+++ b/src/main/java/com/moa/moabackend/member/exception/InvalidMemberTypeException.java
@@ -1,0 +1,13 @@
+package com.moa.moabackend.member.exception;
+
+import com.moa.moabackend.global.error.exception.InvalidGroupException;
+
+public class InvalidMemberTypeException extends InvalidGroupException {
+    public InvalidMemberTypeException(String message) {
+        super(message);
+    }
+
+    public InvalidMemberTypeException() {
+        this("유효하지 않은 회원 유형입니다. INVESTOR 또는 BUSINESS 중 하나여야 합니다.");
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

#8 

## 📝작업 내용

회원 유형 수정하는 기능을 구현합니다.
INVESTOR 또는 BUSINESS 중 하나여야 합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a REST controller for managing member operations, including updating member types.
	- Added functionality to update member types to either "INVESTOR" or "BUSINESS".
	- Created a new `MemberType` enum to categorize member types.

- **Bug Fixes**
	- Implemented error handling for invalid member type inputs.

- **Documentation**
	- Added OpenAPI documentation for the member type update API.

- **Chores**
	- Introduced new exception class for handling invalid member types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->