### PR TITLE
Feat(#11): Add CRUD API

### DIFF
--- a/src/main/java/com/moa/moabackend/store/api/StoreController.java
+++ b/src/main/java/com/moa/moabackend/store/api/StoreController.java
@@ -93,13 +93,15 @@ public class StoreController implements StoreControllerDocs {
         return new RspTemplate<>(HttpStatus.OK, "상점 삭제", true);
     }
 
-    @GetMapping("/map")
-    public RspTemplate<List<Number>> searchStoreByLocation(
-            @RequestBody SearchByLocationReqDto searchByLocationReqDto) {
-        List<Number> stores = storeService.getStoresByLocation(searchByLocationReqDto.radius(),
-                searchByLocationReqDto.x(),
-                searchByLocationReqDto.y()).stream().map(store -> store.getId()).collect(Collectors.toList());
+    // @GetMapping("/map")
+    // public RspTemplate<List<Number>> searchStoreByLocation(
+    // @RequestBody SearchByLocationReqDto searchByLocationReqDto) {
+    // List<Number> stores =
+    // storeService.getStoresByLocation(searchByLocationReqDto.radius(),
+    // searchByLocationReqDto.x(),
+    // searchByLocationReqDto.y()).stream().map(store ->
+    // store.getId()).collect(Collectors.toList());
 
-        return new RspTemplate<>(HttpStatus.OK, "좌표 주변 상점 찾기", stores);
-    }
+    // return new RspTemplate<>(HttpStatus.OK, "좌표 주변 상점 찾기", stores);
+    // }
 }

--- a/src/main/java/com/moa/moabackend/store/api/StoreController.java
+++ b/src/main/java/com/moa/moabackend/store/api/StoreController.java
@@ -1,0 +1,105 @@
+package com.moa.moabackend.store.api;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.moa.moabackend.global.template.RspTemplate;
+import com.moa.moabackend.store.api.dto.request.SearchByLocationReqDto;
+import com.moa.moabackend.store.api.dto.request.StoreReqDto;
+import com.moa.moabackend.store.api.dto.response.StoreResDto;
+import com.moa.moabackend.store.application.StoreService;
+import com.moa.moabackend.store.domain.Store;
+import com.moa.moabackend.store.exception.RevGeocodeNotFoundException;
+
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@RestController
+@RequestMapping("/api/store")
+@RequiredArgsConstructor
+public class StoreController implements StoreControllerDocs {
+
+    private final StoreService storeService;
+
+    @PostMapping("")
+    public RspTemplate<Boolean> createStore(@RequestBody StoreReqDto storeReqDto) {
+        try {
+            storeService.createStore(storeReqDto);
+        } catch (IOException | InterruptedException e) {
+            e.printStackTrace();
+            return new RspTemplate<>(HttpStatus.INTERNAL_SERVER_ERROR, "좌표를 주소로 변환하는데 실패했습니다.", null);
+        } catch (RevGeocodeNotFoundException e) {
+            return new RspTemplate<>(HttpStatus.BAD_REQUEST, "해당하는 좌표로 가게를 찾지 못했습니다.", null);
+        }
+        return new RspTemplate<>(HttpStatus.OK, "상점 생성", true);
+    }
+
+    @GetMapping("/{id}")
+    @Transactional(readOnly = true)
+    public RspTemplate<StoreResDto> getStore(
+            @Parameter(name = "id", description = "상점 ID", in = ParameterIn.PATH) @PathVariable(name = "id") Long storeId) {
+        Store store = storeService.getStore(storeId);
+
+        StoreResDto storeResDto = new StoreResDto(
+                store.getName(),
+                store.getCategory(),
+                store.getProfileImage(),
+                store.getCaption(),
+                store.getFundingTarget(),
+                store.getFundingCurrent(),
+                store.getStoreImages().stream().map(image -> image.getImageUrl()).collect(Collectors.toList()),
+                store.getContent(),
+                store.getStoreLocation().getX(),
+                store.getStoreLocation().getY());
+
+        return new RspTemplate<>(HttpStatus.OK, "상점 조회", storeResDto);
+    }
+
+    @PutMapping("/{id}")
+    public RspTemplate<Boolean> putStore(
+            @Parameter(name = "id", description = "상점 ID", in = ParameterIn.PATH) @PathVariable(name = "id") Long storeId,
+            @RequestBody StoreReqDto storeReqDto) {
+
+        try {
+            storeService.updateStore(storeId, storeReqDto);
+        } catch (IOException | InterruptedException e) {
+            e.printStackTrace();
+            return new RspTemplate<>(HttpStatus.INTERNAL_SERVER_ERROR, "좌표를 주소로 변환하는데 실패했습니다.", null);
+        } catch (RevGeocodeNotFoundException e) {
+            return new RspTemplate<>(HttpStatus.BAD_REQUEST, "해당하는 좌표로 가게를 찾지 못했습니다.", null);
+        }
+
+        return new RspTemplate<>(HttpStatus.OK, "상점 수정", true);
+    }
+
+    @DeleteMapping("/{id}")
+    public RspTemplate<Boolean> deleteStore(
+            @Parameter(name = "id", description = "상점 ID", in = ParameterIn.PATH) @PathVariable(name = "id") Long storeId) {
+        storeService.deleteStore(storeId);
+        return new RspTemplate<>(HttpStatus.OK, "상점 삭제", true);
+    }
+
+    @GetMapping("/map")
+    public RspTemplate<List<Number>> searchStoreByLocation(
+            @RequestBody SearchByLocationReqDto searchByLocationReqDto) {
+        List<Number> stores = storeService.getStoresByLocation(searchByLocationReqDto.radius(),
+                searchByLocationReqDto.x(),
+                searchByLocationReqDto.y()).stream().map(store -> store.getId()).collect(Collectors.toList());
+
+        return new RspTemplate<>(HttpStatus.OK, "좌표 주변 상점 찾기", stores);
+    }
+}

--- a/src/main/java/com/moa/moabackend/store/api/StoreControllerDocs.java
+++ b/src/main/java/com/moa/moabackend/store/api/StoreControllerDocs.java
@@ -1,5 +1,60 @@
 package com.moa.moabackend.store.api;
 
+import org.springframework.web.bind.annotation.PathVariable;
+
+import com.moa.moabackend.global.template.RspTemplate;
+import com.moa.moabackend.store.api.dto.request.StoreReqDto;
+import com.moa.moabackend.store.api.dto.response.StoreResDto;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
 public interface StoreControllerDocs {
 
+    @Operation(summary = "상점 생성", description = "새로운 상점을 생성합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "상점 생성 성공"),
+            @ApiResponse(responseCode = "400", description = "해당하는 좌표로 가게를 찾지 못했습니다."),
+            @ApiResponse(responseCode = "500", description = "좌표를 주소로 변환하는데 실패했습니다.")
+    })
+    RspTemplate<Boolean> createStore(@RequestBody StoreReqDto storeReqDto);
+
+    @Operation(summary = "상점 조회", description = "상점 ID로 상점 정보를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "상점 조회 성공"),
+            @ApiResponse(responseCode = "404", description = "상점을 찾을 수 없습니다.")
+    })
+    RspTemplate<StoreResDto> getStore(
+            @Parameter(name = "id", description = "상점 ID", in = ParameterIn.PATH) @PathVariable(name = "id") Long storeId);
+
+    @Operation(summary = "상점 수정", description = "상점 정보를 수정합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "상점 수정 성공"),
+            @ApiResponse(responseCode = "400", description = "해당하는 좌표로 가게를 찾지 못했습니다."),
+            @ApiResponse(responseCode = "404", description = "수정할 상점을 찾을 수 없습니다."),
+            @ApiResponse(responseCode = "500", description = "좌표를 주소로 변환하는데 실패했습니다.")
+    })
+    RspTemplate<Boolean> putStore(
+            @Parameter(name = "id", description = "상점 ID", in = ParameterIn.PATH) @PathVariable(name = "id") Long storeId,
+            @RequestBody StoreReqDto storeReqDto);
+
+    @Operation(summary = "상점 삭제", description = "상점을 삭제합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "상점 삭제 성공"),
+            @ApiResponse(responseCode = "404", description = "삭제할 상점을 찾을 수 없습니다.")
+    })
+    RspTemplate<Boolean> deleteStore(
+            @Parameter(name = "id", description = "상점 ID", in = ParameterIn.PATH) @PathVariable(name = "id") Long storeId);
+
+    // @Operation(summary = "주변 상점 검색", description = "지정된 좌표 반경 내의 상점들을 검색합니다.")
+    // @ApiResponses(value = {
+    // @ApiResponse(responseCode = "200", description = "상점 검색 성공")
+    // })
+    // RspTemplate<List<Number>> searchStoreByLocation(
+    // @RequestBody SearchByLocationReqDto searchByLocationReqDto
+    // );
 }

--- a/src/main/java/com/moa/moabackend/store/api/StoreControllerDocs.java
+++ b/src/main/java/com/moa/moabackend/store/api/StoreControllerDocs.java
@@ -1,0 +1,5 @@
+package com.moa.moabackend.store.api;
+
+public interface StoreControllerDocs {
+
+}

--- a/src/main/java/com/moa/moabackend/store/api/dto/request/LocationDto.java
+++ b/src/main/java/com/moa/moabackend/store/api/dto/request/LocationDto.java
@@ -1,0 +1,7 @@
+package com.moa.moabackend.store.api.dto.request;
+
+public record LocationDto(
+                Long x,
+                Long y) {
+
+}

--- a/src/main/java/com/moa/moabackend/store/api/dto/request/SearchByLocationReqDto.java
+++ b/src/main/java/com/moa/moabackend/store/api/dto/request/SearchByLocationReqDto.java
@@ -1,0 +1,8 @@
+package com.moa.moabackend.store.api.dto.request;
+
+public record SearchByLocationReqDto(
+        Long radius,
+        Double x,
+        Double y) {
+
+}

--- a/src/main/java/com/moa/moabackend/store/api/dto/request/StoreReqDto.java
+++ b/src/main/java/com/moa/moabackend/store/api/dto/request/StoreReqDto.java
@@ -1,0 +1,16 @@
+package com.moa.moabackend.store.api.dto.request;
+
+import java.util.List;
+
+public record StoreReqDto(
+                String name,
+                String category,
+                String profileImage,
+                String caption,
+                Long fundingTarget,
+                List<String> images,
+                String content,
+                Double x,
+                Double y) {
+
+}

--- a/src/main/java/com/moa/moabackend/store/api/dto/response/AddressResDto.java
+++ b/src/main/java/com/moa/moabackend/store/api/dto/response/AddressResDto.java
@@ -1,0 +1,40 @@
+package com.moa.moabackend.store.api.dto.response;
+
+import java.util.List;
+
+public record AddressResDto(
+                Meta meta,
+                List<Document> documents) {
+        public record Meta(
+                        int total_count) {
+        }
+
+        public record Document(
+                        RoadAddress road_address,
+                        Address address) {
+        }
+
+        public record RoadAddress(
+                        String address_name,
+                        String region_1depth_name,
+                        String region_2depth_name,
+                        String region_3depth_name,
+                        String road_name,
+                        String underground_yn,
+                        String main_building_no,
+                        String sub_building_no,
+                        String building_name,
+                        String zone_no) {
+        }
+
+        public record Address(
+                        String address_name,
+                        String region_1depth_name,
+                        String region_2depth_name,
+                        String region_3depth_name,
+                        String mountain_yn,
+                        String main_address_no,
+                        String sub_address_no,
+                        String zip_code) {
+        }
+}

--- a/src/main/java/com/moa/moabackend/store/api/dto/response/StoreResDto.java
+++ b/src/main/java/com/moa/moabackend/store/api/dto/response/StoreResDto.java
@@ -1,0 +1,17 @@
+package com.moa.moabackend.store.api.dto.response;
+
+import java.util.List;
+
+public record StoreResDto(
+                String name,
+                String category,
+                String profileImage,
+                String caption,
+                Long fundingTarget,
+                Long fundingCurrent,
+                List<String> images,
+                String content,
+                Double x,
+                Double y) {
+
+}

--- a/src/main/java/com/moa/moabackend/store/application/StoreService.java
+++ b/src/main/java/com/moa/moabackend/store/application/StoreService.java
@@ -1,0 +1,177 @@
+package com.moa.moabackend.store.application;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.moa.moabackend.store.api.dto.request.StoreReqDto;
+import com.moa.moabackend.store.api.dto.response.AddressResDto;
+import com.moa.moabackend.store.domain.Store;
+import com.moa.moabackend.store.domain.StoreImage;
+import com.moa.moabackend.store.domain.StoreLocation;
+import com.moa.moabackend.store.domain.repository.StoreImageRepository;
+import com.moa.moabackend.store.domain.repository.StoreLocationRepository;
+import com.moa.moabackend.store.domain.repository.StoreRepository;
+import com.moa.moabackend.store.exception.RevGeocodeNotFoundException;
+
+import jakarta.persistence.EntityNotFoundException;
+
+@Service
+public class StoreService {
+    private final StoreRepository storeRepository;
+    private final StoreImageRepository storeImageRepository;
+    private final StoreLocationRepository storeLocationRepository;
+
+    @Value("${KAKAO_API_KEY}")
+    private String kakaoApiKey;
+
+    public StoreService(StoreRepository storeRepository, StoreImageRepository storeImageRepository,
+            StoreLocationRepository storeLocationRepository) {
+        this.storeRepository = storeRepository;
+        this.storeImageRepository = storeImageRepository;
+        this.storeLocationRepository = storeLocationRepository;
+    }
+
+    @Transactional
+    public Store createStore(StoreReqDto payload) throws JsonProcessingException, IOException, InterruptedException {
+        Double x = payload.x();
+        Double y = payload.y();
+
+        // 1-1. 상점 객체 빌드
+        Store newStore = Store.builder().name(payload.name()).category(payload.category())
+                .profileImage(payload.profileImage()).caption(payload.caption()).fundingCurrent(0)
+                .fundingTarget(payload.fundingTarget()).content(payload.content()).build();
+
+        // 1-2. 상점 등록
+        Store store = storeRepository.save(newStore);
+
+        // 2-1. 상점 이미지 정보를 순차적으로 저장
+        payload.images().stream().forEach(imageUrl -> {
+            StoreImage newStoreImage = StoreImage.builder().imageUrl(imageUrl).store(store).build();
+            storeImageRepository.save(newStoreImage);
+        });
+
+        // 3-1. 상점 좌표 도로명주소로 변환
+        String roadAddress = this.coord2Address(x, y);
+
+        // 3-2. 상점 좌표 정보 저장
+        StoreLocation storeLocation = StoreLocation.builder().address(roadAddress).x(x).y(y).store(store).build();
+        storeLocationRepository.save(storeLocation);
+
+        return store;
+    }
+
+    public Store getStore(Long storeId) {
+        // ID로 상점 찾기
+        Store store = storeRepository.findById(storeId)
+                .orElseThrow(() -> new EntityNotFoundException("ID가 일치하는 상점을 찾을 수 없습니다."));
+
+        return store;
+    }
+
+    @Transactional
+    public void updateStore(Long storeId, StoreReqDto payload)
+            throws JsonProcessingException, IOException, InterruptedException {
+        // TODO(security): 소유자만 상점 정보 변경할 수 있도록 변경
+
+        // 1. 받은 storeId로 상점 존재 검사 및 객체 확보
+        Store store = storeRepository.findById(storeId)
+                .orElseThrow(() -> new EntityNotFoundException("ID가 일치하는 상점을 찾을 수 없습니다."));
+
+        // 2-1. 받은 상점 정보로 기존 상점 정보 업데이트
+        storeRepository.updateStoreInfo(storeId, payload.name() != null ? payload.name() : store.getName(),
+                payload.category() != null ? payload.category() : store.getCategory(),
+                payload.profileImage() != null ? payload.profileImage() : store.getProfileImage(),
+                payload.caption() != null ? payload.caption() : store.getCaption(),
+                payload.content() != null ? payload.content() : store.getContent(),
+                payload.fundingTarget() != null ? payload.fundingTarget() : store.getFundingTarget());
+
+        if (payload.images() != null) {
+            // 3-1. 기존 상점 이미지 정보 제거
+            storeImageRepository.deleteByStore_Id(storeId);
+
+            // 3-2. 업데이트를 희망하는 상점 이미지 정보를 순차적으로 저장
+            payload.images().stream().forEach(imageUrl -> {
+                StoreImage newStoreImage = StoreImage.builder().imageUrl(imageUrl).store(store).build();
+                storeImageRepository.save(newStoreImage);
+            });
+        }
+
+        if (payload.x() != null && payload.y() != null) {
+            // 4-1. 상점 좌표 도로명주소로 변환
+            String roadAddress = this.coord2Address(payload.x(), payload.y());
+
+            // 4-2. 상점 좌표 정보 저장
+            storeLocationRepository.deleteByStoreId(storeId);
+            StoreLocation storeLocation = StoreLocation.builder().address(roadAddress).x(payload.x()).y(payload.y())
+                    .store(store)
+                    .build();
+            storeLocationRepository.save(storeLocation);
+        }
+
+    }
+
+    public void deleteStore(Long storeId) {
+        Store store = getStore(storeId);
+        storeRepository.delete(store);
+    }
+
+    public List<Store> getAllStores() {
+        return storeRepository.findAll();
+    }
+
+    public List<Store> getStoresByLocation(Long radius, Double x, Double y) {
+        // 1. 좌표 주변에 있는 상점들의 ID를 가져옴
+        List<StoreLocation> storeIdList = storeLocationRepository.findStoresWithinDistance(x, y, radius)
+                .orElseThrow(() -> new EntityNotFoundException("ID가 일치하는 상점을 찾을 수 없습니다."));
+
+        // 2. 받아온 상점 좌표 객체들을 다시 상점 객체로 변환 후 저장
+        List<Store> result = new ArrayList<Store>();
+        for (StoreLocation storeLocation : storeIdList) {
+            result.add(storeLocation.getStore());
+        }
+
+        // 3. 좌표 주변에 있는 상점들의 상점 정보 반환
+        return result;
+    }
+
+    public String coord2Address(Double x, Double y)
+            throws IOException, InterruptedException, JsonProcessingException {
+        System.out.println("x:" + x + ", y:" + y);
+        // 1. 카카오맵 API 요청 (리버스 지오코딩)
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(
+                        String.format(
+                                "https://dapi.kakao.com/v2/local/geo/coord2address.json?input_coord=WGS84&x=%s&y=%s", x,
+                                y)))
+                .header("Authorization", "KakaoAK " + kakaoApiKey)
+                .method("GET", HttpRequest.BodyPublishers.noBody())
+                .build();
+
+        HttpResponse<String> response = HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
+
+        System.out.println(response.body());
+
+        // 2. 받은 응답을 파싱, DTO 불일치하면 JsonProcessingException 예외 발생
+        ObjectMapper objectMapper = new ObjectMapper();
+        AddressResDto addressResponse = objectMapper.readValue(response.body(), AddressResDto.class);
+
+        List<AddressResDto.Document> documents = addressResponse.documents();
+
+        // 3. 파싱된 객체에서 도로명주소 반환
+        if (documents.size() < 1) {
+            throw new RevGeocodeNotFoundException();
+        }
+        return documents.get(0).road_address().address_name();
+    }
+}

--- a/src/main/java/com/moa/moabackend/store/domain/Store.java
+++ b/src/main/java/com/moa/moabackend/store/domain/Store.java
@@ -36,6 +36,8 @@ public class Store extends BaseEntity {
 
     private String caption;
 
+    private String content;
+
     private long fundingCurrent;
 
     private long fundingTarget;
@@ -59,12 +61,15 @@ public class Store extends BaseEntity {
     private List<VoucherBarcode> voucherBarcodes = new ArrayList<>();
 
     @Builder
-    private Store(String name, String category, String profileImage, String caption, long fundingCurrent,
-                  long fundingTarget, StoreLocation storeLocation) {
+    private Store(Long id, String name, String category, String profileImage, String caption, String content,
+            long fundingCurrent,
+            long fundingTarget, StoreLocation storeLocation) {
+        this.id = id;
         this.name = name;
         this.category = category;
         this.profileImage = profileImage;
         this.caption = caption;
+        this.content = content;
         this.fundingCurrent = fundingCurrent;
         this.fundingTarget = fundingTarget;
         this.storeLocation = storeLocation;

--- a/src/main/java/com/moa/moabackend/store/domain/StoreImage.java
+++ b/src/main/java/com/moa/moabackend/store/domain/StoreImage.java
@@ -35,5 +35,5 @@ public class StoreImage extends BaseEntity {
         this.imageUrl = imageUrl;
         this.store = store;
     }
-    
+
 }

--- a/src/main/java/com/moa/moabackend/store/domain/StoreLocation.java
+++ b/src/main/java/com/moa/moabackend/store/domain/StoreLocation.java
@@ -25,16 +25,16 @@ public class StoreLocation {
 
     private String address;
 
-    private String x;
+    private Double x;
 
-    private String y;
+    private Double y;
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "store_id")
     private Store store;
 
     @Builder
-    private StoreLocation(String address, String x, String y, Store store) {
+    private StoreLocation(String address, Double x, Double y, Store store) {
         this.address = address;
         this.x = x;
         this.y = y;

--- a/src/main/java/com/moa/moabackend/store/domain/repository/StoreImageRepository.java
+++ b/src/main/java/com/moa/moabackend/store/domain/repository/StoreImageRepository.java
@@ -1,0 +1,22 @@
+package com.moa.moabackend.store.domain.repository;
+
+import com.moa.moabackend.store.domain.StoreImage;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StoreImageRepository extends JpaRepository<StoreImage, Long> {
+    Optional<StoreImage> findById(Long id);
+
+    @Override
+    <S extends StoreImage> S save(S storeImage);
+
+    void deleteByStore_Id(Long storeId);
+
+    // @Modifying
+    // @Query("UPDATE StoreImage s SET s = :storeImage WHERE s.id = :id")
+    // void updateStoreById(Long id, StoreImage storeImage);
+
+    void deleteById(Long id);
+
+}

--- a/src/main/java/com/moa/moabackend/store/domain/repository/StoreLocationRepository.java
+++ b/src/main/java/com/moa/moabackend/store/domain/repository/StoreLocationRepository.java
@@ -1,0 +1,29 @@
+package com.moa.moabackend.store.domain.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.moa.moabackend.store.domain.StoreLocation;
+
+public interface StoreLocationRepository extends JpaRepository<StoreLocation, Long> {
+        @Query(value = "SELECT * FROM store_location " +
+                        "WHERE (6371 * acos(cos(radians(:latitude)) * cos(radians(latitude)) * " +
+                        "cos(radians(longitude) - radians(:longitude)) + sin(radians(:latitude)) * " +
+                        "sin(radians(latitude)))) <= :distance", nativeQuery = true)
+        Optional<List<StoreLocation>> findStoresWithinDistance(
+                        @Param("longitude") double x,
+                        @Param("latitude") double y,
+                        @Param("distance") long radius);
+
+        @Override
+        <S extends StoreLocation> S save(S storeLocation);
+
+        @Modifying
+        @Query("DELETE FROM StoreLocation sl WHERE sl.store.id = :storeId")
+        void deleteByStoreId(@Param("storeId") Long storeId);
+}

--- a/src/main/java/com/moa/moabackend/store/domain/repository/StoreRepository.java
+++ b/src/main/java/com/moa/moabackend/store/domain/repository/StoreRepository.java
@@ -1,0 +1,35 @@
+package com.moa.moabackend.store.domain.repository;
+
+import com.moa.moabackend.store.domain.Store;
+
+import jakarta.transaction.Transactional;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface StoreRepository extends JpaRepository<Store, Long> {
+    Optional<Store> findById(Long id);
+
+    Optional<Store> findByName(String name);
+
+    @Override
+    <S extends Store> S save(S store);
+
+    @Modifying
+    @Transactional
+    @Query("UPDATE Store s SET s.name = :name, s.category = :category, s.profileImage = :profileImage, s.caption = :caption, s.content = :content, s.fundingTarget = :fundingTarget WHERE s.id = :id")
+    void updateStoreInfo(@Param("id") Long id, @Param("name") String name, @Param("category") String category,
+            @Param("profileImage") String profileImage, @Param("caption") String caption,
+            @Param("content") String content, @Param("fundingTarget") Long fundingTarget);
+
+    // @Modifying
+    // @Transactional
+    // @Query("UPDATE Store s SET s = :store WHERE s.id = :id")
+    // void updateStoreById(@Param("id") Long id, @Param("store") Store store);
+
+    void deleteById(Long id);
+
+}

--- a/src/main/java/com/moa/moabackend/store/exception/RevGeocodeNotFoundException.java
+++ b/src/main/java/com/moa/moabackend/store/exception/RevGeocodeNotFoundException.java
@@ -1,0 +1,13 @@
+package com.moa.moabackend.store.exception;
+
+import com.moa.moabackend.global.error.exception.NotFoundGroupException;
+
+public class RevGeocodeNotFoundException extends NotFoundGroupException {
+    public RevGeocodeNotFoundException(String message) {
+        super(message);
+    }
+
+    public RevGeocodeNotFoundException() {
+        this("해당하는 좌표로 가게를 찾지 못했습니다.");
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

#11 

## 📝작업 내용

**Store API 중 CRUD 작업을 추가했습니다.**
따라서 관련된 DTO, 컨트롤러, 서비스, 레포지토리를 추가했습니다.

**도메인도 일부 변경되었습니다.**
`StoreLocation`은 이후 진행될 좌표 연산을 위해 `x`, `y`를 `Double`로 형변환 했으며,
`Store`의 Builder는 update시에 상점을 식별하기 위해 ID 필드를 추가했습니다.

## 💬리뷰 요구사항(선택)
JPA 사용하는 부분이 좀 익숙치 않았습니다. 그래서 레포지토리 작성이 원활치 못했습니다.
따라서 JPA 측에서 쿼리를 자동 생성해줌에도 불구하고, 로우쿼리로 넣은 부분등의 미숙한 부분을 봐주시면 좋겠습니다.